### PR TITLE
Fix `SyntaxError` in `webpack.config.js`

### DIFF
--- a/_dev/webpack.config.js
+++ b/_dev/webpack.config.js
@@ -17,6 +17,6 @@ const getConfig = ({mode, ...vars}) => {
 
 module.exports = (env, options) => getConfig({
   mode: options.mode,
-  purge: options?.purge ? options.purge : false,
+  purge: options.purge ? options.purge : false,
   ...webpackVars
 });


### PR DESCRIPTION

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | During the installation process (step 6), when you try to run `npm run dev`
| Type?             | bug fix
| BC breaks?        | N/A 
| Deprecations?     | N/A
| Fixed ticket?     | Fixes https://github.com/Oksydan/modern-prestashop-starter-theme/issues/15
| How to test?      | Make sure you can run : `npm run dev` and it work fine!
