### PR TITLE
Product thumbnails displayAfterProductThumbs fix

### DIFF
--- a/templates/catalog/_partials/product-cover-thumbnails.tpl
+++ b/templates/catalog/_partials/product-cover-thumbnails.tpl
@@ -47,6 +47,7 @@
         {/images_block}
       </div>
     </div>
+    {hook h='displayAfterProductThumbs' product=$product}
   </div>
 {else}
   <div class="js-product-images">
@@ -183,6 +184,6 @@
         </div>
       {/if}
     {/block}
+    {hook h='displayAfterProductThumbs' product=$product}
   </div>
-  {hook h='displayAfterProductThumbs' product=$product}
 {/if}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | Fix to hook `displayAfterProductThumbs` content duplication. The content of the hook is right now also displayed in the quick view.
| Type?             | bug fix
| Fixed ticket?     | https://github.com/Oksydan/falcon/issues/362
