### PR TITLE
default to base_url when $page.canonical is not defined

### DIFF
--- a/templates/_partials/head.tpl
+++ b/templates/_partials/head.tpl
@@ -41,6 +41,8 @@
   {/if}
   {if $page.canonical}
     <link rel="canonical" href="{$page.canonical}">
+  {else}
+    <link rel="canonical" href="{$urls.base_url}">
   {/if}
   {block name='head_hreflang'}
     {foreach from=$urls.alternative_langs item=pageUrl key=code}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | Updated the template to set the shop's main page as the default canonical URL when {$page.canonical} is not set. This ensures proper SEO behavior by using the shop's main page as a fallback for canonical URLs.
| Type?             | improvement
| Fixed ticket?     | #437 
